### PR TITLE
Allow cropping image to a specified width and height.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.pyc
 *.egg
+.installed.cfg
+bin/
+develop-eggs/
+include/
+lib
 /repoze.bitblt.egg-info

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,10 @@ x.y (released unknown)
   remove the Content-Length header as we cannot calculate the right
   value without knowing the image.
 
+- Use Pillow instead of PIL which is unmaintained for years now.
+
+- Allow cropping image to a specified width and height.
+
 0.9 (released 2012-10-18)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,52 @@
+##############################################################################
+#
+# Copyright (c) 2006 Zope Corporation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Bootstrap a buildout-based project
+
+Simply run this script in a directory containing a buildout.cfg.
+The script accepts buildout command-line options, so you can
+use the -c option to specify an alternate configuration file.
+
+$Id: bootstrap.py 72703 2007-02-20 11:49:26Z jim $
+"""
+
+import os, shutil, sys, tempfile, urllib2
+
+tmpeggs = tempfile.mkdtemp()
+
+ez = {}
+exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
+                     ).read() in ez
+ez['use_setuptools'](to_dir=tmpeggs, download_delay=0)
+
+import pkg_resources
+
+cmd = 'from setuptools.command.easy_install import main; main()'
+if sys.platform == 'win32':
+    cmd = '"%s"' % cmd # work around spawn lamosity on windows
+
+ws = pkg_resources.working_set
+assert os.spawnle(
+    os.P_WAIT, sys.executable, sys.executable,
+    '-c', cmd, '-mqNxd', tmpeggs, 'zc.buildout',
+    dict(os.environ,
+         PYTHONPATH=
+         ws.find(pkg_resources.Requirement.parse('setuptools')).location
+         ),
+    ) == 0
+
+ws.add_entry(tmpeggs)
+ws.require('zc.buildout')
+import zc.buildout.buildout
+zc.buildout.buildout.main(sys.argv[1:] + ['bootstrap'])
+shutil.rmtree(tmpeggs)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,10 @@
+[buildout]
+develop = .
+parts = test
+find-links = http://pypi.python.org/simple
+allow-hosts = *
+
+[test]
+recipe = zc.recipe.testrunner
+eggs = repoze.bitblt
+defaults = ['--tests-pattern', '^f?tests$', '-v', '--color', '--exit-with-status']

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name='repoze.bitblt',
       namespace_packages=['repoze'],
       zip_safe=False,
       install_requires=[
-           'PIL',
+           'Pillow',
            'WebOb',
            ],
       test_suite="repoze.bitblt.tests",


### PR DESCRIPTION
Hi,

I added a new feature to be able to crop an image, if dimensions of the target image are not equal to the one from the original image. That means, if your original image is say 100x200px and your target image is 50x50px, you really get a 50x50px image instead of a 25x50px image.

I also changed dependencies from PIL to Pillow, which is much better maintained.

I also added a buildout.cfg and bootstrap.py to be able to run tests in a buildout supported environment.
